### PR TITLE
Post 목록 페이지 및 상세 페이지 리펙토링

### DIFF
--- a/components/post/PostListItem.tsx
+++ b/components/post/PostListItem.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { MetadataType } from 'interfaces/post';
+
+const PostListItem = ({ slug, metadata }: MetadataType) => {
+  return (
+    <div className="flex flex-col mb-10" key={slug}>
+      <Link
+        href={{
+          pathname: '/post/[slug]',
+          query: { slug },
+        }}
+      >
+        <p className="text-xl text-bold">{metadata.title}</p>
+      </Link>
+      <p>{metadata.summary}</p>
+      <p>{metadata.date}</p>
+      <p>{metadata.category}</p>
+    </div>
+  );
+};
+
+export default PostListItem;

--- a/interfaces/post.ts
+++ b/interfaces/post.ts
@@ -1,7 +1,11 @@
 export type PostType = {};
 
-export type MetadataType = {
+export type AllMetadataType = {
   slug: string;
+  metadata: MetadataType;
+};
+
+export type MetadataType = {
   metadata: {
     title: string;
     summary: string;

--- a/interfaces/post.ts
+++ b/interfaces/post.ts
@@ -1,0 +1,11 @@
+export type PostType = {};
+
+export type MetadataType = {
+  slug: string;
+  metadata: {
+    title: string;
+    summary: string;
+    date: string;
+    category: string;
+  };
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -13,9 +13,9 @@ export const getMetaDataFromMarkdown = (markdownFile: string) => {
     'utf-8'
   );
 
-  const { data: metaData } = matter(metaDataFromMarkdown);
+  const { data: metadata } = matter(metaDataFromMarkdown);
 
-  return metaData;
+  return metadata;
 };
 
 export const getSlugFromMarkdown = (markdownFile: string) => {
@@ -25,11 +25,11 @@ export const getSlugFromMarkdown = (markdownFile: string) => {
 export const getAllMetadata = () => {
   const allMetadata = getMarkdownFiles().map((file) => {
     const slug = getSlugFromMarkdown(file);
-    const metaData = getMetaDataFromMarkdown(file);
+    const metadata = getMetaDataFromMarkdown(file);
 
     return {
       slug,
-      metaData,
+      metadata,
     };
   });
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { MARKDOWN_DIRECTORY, MARKDOWN_FILENAME_EXTENSION } from 'lib/constants';
+
+export const getMarkdownFiles = () => {
+  return fs.readdirSync(path.join(MARKDOWN_DIRECTORY));
+};
+
+export const getMetaDataFromMarkdown = (markdownFile: string) => {
+  const metaDataFromMarkdown = fs.readFileSync(
+    path.join(MARKDOWN_DIRECTORY, markdownFile),
+    'utf-8'
+  );
+
+  const { data: metaData } = matter(metaDataFromMarkdown);
+
+  return metaData;
+};
+
+export const getSlugFromMarkdown = (markdownFile: string) => {
+  return markdownFile.replace(MARKDOWN_FILENAME_EXTENSION, '');
+};
+
+export const getAllMetadata = () => {
+  const allMetadata = getMarkdownFiles().map((file) => {
+    const slug = getSlugFromMarkdown(file);
+    const metaData = getMetaDataFromMarkdown(file);
+
+    return {
+      slug,
+      metaData,
+    };
+  });
+
+  return allMetadata;
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,20 +2,26 @@ import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
 import { MARKDOWN_DIRECTORY, MARKDOWN_FILENAME_EXTENSION } from 'lib/constants';
+import { markdownToHtml } from 'lib/markdownToHtml';
 
-export const getMarkdownFiles = () => {
+export const getAllMarkdown = (): string[] => {
   return fs.readdirSync(path.join(MARKDOWN_DIRECTORY));
 };
 
-export const getMetaDataFromMarkdown = (markdownFile: string) => {
-  const metaDataFromMarkdown = fs.readFileSync(
-    path.join(MARKDOWN_DIRECTORY, markdownFile),
-    'utf-8'
-  );
+export const getMarkdown = (filename: string = '') => {
+  return fs
+    .readFileSync(path.join(MARKDOWN_DIRECTORY, filename + MARKDOWN_FILENAME_EXTENSION), 'utf-8')
+    .toString();
+};
 
-  const { data: metadata } = matter(metaDataFromMarkdown);
+export const getDataFromMarkdown = (
+  markdownFile: string
+): { metadata: { [key: string]: string }; content: string } => {
+  const dataFromMarkdown = fs.readFileSync(path.join(MARKDOWN_DIRECTORY, markdownFile), 'utf-8');
 
-  return metadata;
+  const { data: metadata, content } = matter(dataFromMarkdown);
+
+  return { metadata, content };
 };
 
 export const getSlugFromMarkdown = (markdownFile: string) => {
@@ -23,9 +29,9 @@ export const getSlugFromMarkdown = (markdownFile: string) => {
 };
 
 export const getAllMetadata = () => {
-  const allMetadata = getMarkdownFiles().map((file) => {
+  const allMetadata = getAllMarkdown().map((file) => {
     const slug = getSlugFromMarkdown(file);
-    const metadata = getMetaDataFromMarkdown(file);
+    const { metadata } = getDataFromMarkdown(file);
 
     return {
       slug,
@@ -34,4 +40,11 @@ export const getAllMetadata = () => {
   });
 
   return allMetadata;
+};
+
+export const getAllData = async (slug: string) => {
+  const markdown = getDataFromMarkdown(slug + MARKDOWN_FILENAME_EXTENSION);
+  const html = await markdownToHtml(markdown.content);
+
+  return { metadata: markdown.metadata, html: html.value };
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+export const MARKDOWN_DIRECTORY = '__post';
+export const MARKDOWN_FILENAME_EXTENSION = '.md';

--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -1,0 +1,9 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkHtml from 'remark-html';
+
+export const markdownToHtml = async (markdown: string) => {
+  const html = await unified().use(remarkParse).use(remarkHtml).process(markdown);
+
+  return html;
+};

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -1,62 +1,29 @@
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
-import React from 'react';
-import { GetStaticProps, InferGetStaticPropsType } from 'next';
-import Link from 'next/link';
+import { GetStaticProps } from 'next';
+import { getAllMetadata } from 'lib/api';
+import PostListItem from 'components/post/PostListItem';
+import { MetadataType } from 'interfaces/post';
 
-type Post = {
-  slug: string;
-  frontmatter: {
-    title: string;
-    summary: string;
-    date: string;
-    category: string;
-  };
+type Props = {
+  allMetadata: MetadataType[];
 };
 
-const Post = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
+const Post = ({ allMetadata }: Props) => {
   return (
     <div>
       <h1 className="text-3xl">Posts</h1>
-      {posts.map(({ slug, frontmatter }: Post) => (
-        <div className="flex flex-col mb-10" key={slug}>
-          <Link
-            href={{
-              pathname: '/post/[slug]',
-              query: { slug },
-            }}
-          >
-            <p className="text-xl text-bold ">{frontmatter.title}</p>
-          </Link>
-          <p>{frontmatter.summary}</p>
-          <p>{frontmatter.date}</p>
-          <p>{frontmatter.category}</p>
-        </div>
+      {allMetadata.map(({ slug, metadata }: MetadataType) => (
+        <PostListItem slug={slug} metadata={metadata} />
       ))}
     </div>
   );
 };
 
-export const getStaticProps: GetStaticProps = async (context) => {
-  const files = fs.readdirSync(path.join('__post'));
-
-  const posts = files.map((file) => {
-    const slug = file.replace('.md', '');
-
-    const metadata = fs.readFileSync(path.join('__post', file), 'utf-8');
-
-    const { data: frontmatter } = matter(metadata);
-
-    return {
-      slug,
-      frontmatter,
-    };
-  });
+export const getStaticProps: GetStaticProps = async () => {
+  const allMetadata = getAllMetadata();
 
   return {
     props: {
-      posts,
+      allMetadata,
     },
   };
 };

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -1,17 +1,17 @@
 import { GetStaticProps } from 'next';
 import { getAllMetadata } from 'lib/api';
 import PostListItem from 'components/post/PostListItem';
-import { MetadataType } from 'interfaces/post';
+import { AllMetadataType } from 'interfaces/post';
 
 type Props = {
-  allMetadata: MetadataType[];
+  allMetadata: AllMetadataType[];
 };
 
 const Post = ({ allMetadata }: Props) => {
   return (
     <div>
       <h1 className="text-3xl">Posts</h1>
-      {allMetadata.map(({ slug, metadata }: MetadataType) => (
+      {allMetadata.map(({ slug, metadata }: AllMetadataType) => (
         <PostListItem slug={slug} metadata={metadata} />
       ))}
     </div>


### PR DESCRIPTION
## 수정 사항

- 관심사의 분리에 따라 목록 페이지 함수 분리
- fs 모듈을 활용하는 모든 로직 분리
- `getMarkdownFiles`, `getMetaDataFromMarkdown`, `getSlugFromMarkdown` 로 분리
- `getAllMetadata`로 모든 메타 데이터 반환 함수 처리
- 마크다운 파일 관련 재사용되는 상수 값 분리
- `PostListItem`을 새로운 컴포넌트로 분리
- 관심사의 분리에 따라 분리된 함수 수정 및 추가적으로 `getAllData` 분리